### PR TITLE
MonthsSlider: move in all state and helpers

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -147,6 +147,8 @@
 
 .slider-container {
   position: absolute;
+  display: flex;
+  flex-direction: row
   top: 83vh;
   left: 4vw;
   z-index: 0;
@@ -156,8 +158,6 @@
   background-color: black;
   color: white;
   border-radius: 10px;
-  position: absolute;
-  top: 83vh;
   right: 2vw;
   width: 12vw;
   z-index: 0;
@@ -218,11 +218,8 @@
 
 
   #toMain2 {
-    top: 88vh;
     width: 10vw;
     height: 8vh;
-    
-
   }
 
   #plusBoton{
@@ -252,7 +249,6 @@
 
 
   #toMain2 {
-    top: 80vh;
     width: 8vw;
     height: 12vh;
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -193,7 +193,7 @@ function App() {
         <BsAsSource data={departamentosBsAs} style={style.country} />
         <RutasSource data={rutas} style={style.rutas}/>
 
-        {filteredData && filteredData.length && (
+        {!!(filteredData && filteredData.length) && (
           <Markers
             data={filteredData}
             setPopupInfo={setPopupInfo}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,8 +21,6 @@ import mystyle from "./mystyle.json";
 import MonthsSlider from "./components/MonthsSlider.jsx";
 
 //estilos/////////////////////
-const now = new Date()
-
 const style = {
   country: {
     fillColor: "#bacbff",
@@ -63,11 +61,12 @@ const style = {
   },
 };
 
-const emptyFilters = {byId: {}, byName: {}};
-
 function App() {
   const {urls} = useLoaderData();
   const {provincias, departamentos, departamentosBsAs, rutas} = urls;
+  const {tipos, componentes} = urls.casos;
+  const cases = urls.casos.cases.map(c => ({...c, date: new Date(c.date)}))
+  const globalDates = {min: new Date(urls.casos.min), max: new Date(urls.casos.max)};
 
   const handleTipoFilter = () => {
     const filteredDataByType = filteredDataByTime.filter(event => tipoFilters[event.tipoId]);
@@ -81,12 +80,11 @@ function App() {
 
   });
   // Estado para controlar la visibilidad de "Filtros"
-  const [casesData, setCasesData] = useState([]);
   const [analisisData, setAnalisisData] = useState({
-    min: now,
-    max: now,
-    tipos: emptyFilters,
-    componentes: emptyFilters
+    tipos, componentes,
+    min: globalDates.min,
+    max: globalDates.max,
+    total:cases.length
   });
 
   const [filtrosVisible, setFiltrosVisible] = useState(true);
@@ -95,45 +93,20 @@ function App() {
   const [hoveredMarkerId, setHoveredMarkerId] = useState(null);
   const [popupInfo, setPopupInfo] = useState(null);
 
-  const [filteredData, setFilteredData] = useState(casesData);
-  const [months, setMonths] = useState(0);
-  const [dates, setDates] = useState({min: now, max: now});
-  const [monthRange, setMonthRange] = useState([0, 0]);
+  const [dates, setDates] = useState(globalDates);
+  const [filteredData, setFilteredData] = useState(cases);
   const [filteredDataByTime, setFilteredDataByTime] = useState([]);
 
-  useEffect(() => {
-    const {tipos, componentes} = urls.casos;
-    const cases = urls.casos.cases.map(c => ({...c, date: new Date(c.date)}));
-    const max = new Date(urls.casos.max)
-    const min = new Date(urls.casos.min)
-    const yearsDiff = max.getFullYear() - min.getFullYear();
-    const monthDiff = max.getMonth() - min.getMonth();
-
-    const totalMonths = yearsDiff * 12 + monthDiff + 1;
-
-    setCasesData(cases);
-    setAnalisisData({tipos, componentes, min, max, total: cases.length})
-    setDates({min, max});
-    setMonths(totalMonths);
-    setMonthRange([0, totalMonths]);
-  }, [])
-
-  useEffect(() => setFilteredData(casesData), [casesData])
 
   useEffect(() => {
-    const from = new Date(dates.min)
-    from.setMonth(from.getMonth() + monthRange[0])
+    const checkDate = (e) => e.date >= dates.min && e.date <= dates.max;
+    const newData = cases.filter(checkDate);
 
-    const to = new Date(dates.min)
-    to.setMonth(to.getMonth() + monthRange[1])
-
-    const checkDate = (e) => e.date >= from && e.date <= to;
-    const newData = casesData.filter(checkDate);
     setFilteredDataByTime(newData);
     // Aplicar también los filtros de tipo a los datos filtrados por tiempo
     const filteredDataByType = newData.filter(event => tipoFilters[event.tipoId]);
     setFilteredData(filteredDataByType);
-  }, [monthRange, dates, casesData, tipoFilters]);
+  }, [dates, tipoFilters]);
 
   // Función para cambiar la visibilidad de "Filtros"
   const toggleFiltrosVisibility = () => {
@@ -220,7 +193,7 @@ function App() {
         <BsAsSource data={departamentosBsAs} style={style.country} />
         <RutasSource data={rutas} style={style.rutas}/>
 
-        {casesData && (
+        {filteredData && filteredData.length && (
           <Markers
             data={filteredData}
             setPopupInfo={setPopupInfo}
@@ -233,26 +206,20 @@ function App() {
         <NavigationControl position="top-right" />
       </MapGL>
 
-      <MonthsSlider
-          className="slider-container"
-          monthRange={monthRange}
-          setMonthRange={setMonthRange}
-          totalMonths={months}
-          startDateLabel="2/2020"
-          endDateLabel="9/2023"
-        />  
-
-      <ScrollLink id='toMain2Container'
-                  to="Main2" // ID del elemento de destino (Main2)
-                  spy={true} // Activa el modo espía
-                  smooth={true} // Activa el desplazamiento suave
-                  duration={500} // Duración de la animación (en milisegundos)
-                  offset={-70} // Ajusta un offset opcional (si tienes un encabezado fijo)
-      >
-        <div id="toMain2">
-          <h4 id='plusBoton'>+</h4>
-        </div>
-      </ScrollLink>
+      <div className="slider-container">
+        <MonthsSlider {...{globalDates, setDates}}/>
+        <ScrollLink id='toMain2Container'
+                    to="Main2" // ID del elemento de destino (Main2)
+                    spy={true} // Activa el modo espía
+                    smooth={true} // Activa el desplazamiento suave
+                    duration={500} // Duración de la animación (en milisegundos)
+                    offset={-70} // Ajusta un offset opcional (si tienes un encabezado fijo)
+        >
+          <div id="toMain2">
+            <h4 id='plusBoton'>+</h4>
+          </div>
+        </ScrollLink>
+      </div>
 
       {popupInfo && <Popup {...popupInfo} />}
 

--- a/src/components/MonthsSlider.jsx
+++ b/src/components/MonthsSlider.jsx
@@ -15,7 +15,6 @@ export default function MonthsSlider({className, globalDates, setDates}) {
   const months = monthsDiff(globalDates.min, globalDates.max)
   const [monthRange, setMonthRange] = useState([0, months]);
 
-  // Esto da una warning en el linter porque no tiene información de tipado.
   const valueLabelFormat = useCallback((value) => {
     const diff = months - value;
     const date = new Date()
@@ -38,7 +37,6 @@ export default function MonthsSlider({className, globalDates, setDates}) {
 
   return (
     <div className={`months-slider ${className ?? ""}`}>
-      {/* Agrega un botón o elemento para cambiar la visibilidad de Filtros */}
       <Slider
         max={months}
         valueLabelDisplay="auto"

--- a/src/components/MonthsSlider.jsx
+++ b/src/components/MonthsSlider.jsx
@@ -1,4 +1,4 @@
-import {useState, useEffect, useCallback} from "react";
+import {useState, useCallback, useEffect, useMemo} from "react";
 import PropTypes from "prop-types";
 import { Slider } from "@mui/material";
 
@@ -12,7 +12,7 @@ const monthsDiff = (b, a) => {
 }
 
 export default function MonthsSlider({className, globalDates, setDates}) {
-  const months = monthsDiff(globalDates.min, globalDates.max)
+  const months = useMemo(monthsDiff(globalDates.min, globalDates.max), [globalDates])
   const [monthRange, setMonthRange] = useState([0, months]);
 
   const valueLabelFormat = useCallback((value) => {
@@ -20,7 +20,7 @@ export default function MonthsSlider({className, globalDates, setDates}) {
     const date = new Date()
     date.setMonth(date.getMonth() - diff)
     return date2MonthYear(date)
-  }, [])
+  }, [months])
 
   // Uso useCallback para evitar que se re-declare la función anónima en cada render
   const handleChange = useCallback((event) => {

--- a/src/components/MonthsSlider.jsx
+++ b/src/components/MonthsSlider.jsx
@@ -1,53 +1,78 @@
-import PropTypes from "prop-types"
-import { useCallback } from "react";
+import {useState, useEffect, useCallback} from "react";
+import PropTypes from "prop-types";
 import { Slider } from "@mui/material";
+
 import "./MonthsSlider.css";
 
-const valueLabelFormatByMonths = (totalMonths) => (value) => {
-    const diff = totalMonths - value;
+const date2MonthYear = d => `${d.getMonth()}/${d.getFullYear()}`
+const monthsDiff = (b, a) => {
+  const yearsDiff = a.getFullYear() - b.getFullYear();
+  const monthDiff = a.getMonth() - b.getMonth();
+  return yearsDiff * 12 + monthDiff;
+}
+
+export default function MonthsSlider({className, globalDates, setDates}) {
+  const months = monthsDiff(globalDates.min, globalDates.max)
+  const [monthRange, setMonthRange] = useState([0, months]);
+
+  // Esto da una warning en el linter porque no tiene información de tipado.
+  const valueLabelFormat = useCallback((value) => {
+    const diff = months - value;
     const date = new Date()
-    date.setMonth(date.getMonth() - diff - 1)
-    return `${date.getMonth()}/${date.getFullYear()}`;
-};
-/** Agrega un botón o elemento para cambiar la visibilidad de Filtros */
-export default function MonthsSlider({ className, monthRange, setMonthRange, totalMonths, startDateLabel, endDateLabel }) {
+    date.setMonth(date.getMonth() - diff)
+    return date2MonthYear(date)
+  }, [])
 
-    // Uso useCallback para evitar que se re-declare la función anónima en cada render
-    const handleChange = useCallback((event) => {
-        setMonthRange(event.target.value);
-    }, [setMonthRange]);
+  // Uso useCallback para evitar que se re-declare la función anónima en cada render
+  const handleChange = useCallback((event) => {
+    const range = event.target.value
+    const min = new Date(globalDates.min)
+    const max = new Date(globalDates.min)
 
-    // Esto da una warning en el linter porque no tiene información de tipado. La lista de dependencias es exhaustiva.
-    const valueLabelFormat = useCallback(valueLabelFormatByMonths(totalMonths), [totalMonths]);
+    max.setMonth(min.getMonth() + range[1])
+    min.setMonth(min.getMonth() + range[0])
 
-    return (<div className={`months-slider ${className ?? ""}`}>
-        <Slider
-            max={totalMonths}
-            valueLabelDisplay="auto"
-            value={monthRange}
-            step={1}
-            getAriaValueText={valueLabelFormat}
-            valueLabelFormat={valueLabelFormat}
-            onChange={handleChange}
-            aria-labelledby="non-linear-slider"
-        />
-        <div id='referenciasFechas'>
-            <div> <h6 id='fechaInicio'>{startDateLabel}</h6>  </div>
-            <div>  </div>
-            <div> <h6 id='fechaCierre'>{endDateLabel}</h6>  </div>
+    setMonthRange(range);
+    setDates({min,max})
+  }, [])
+
+  return (
+    <div className={`months-slider ${className ?? ""}`}>
+      {/* Agrega un botón o elemento para cambiar la visibilidad de Filtros */}
+      <Slider
+        max={months}
+        valueLabelDisplay="auto"
+        value={monthRange}
+        step={1}
+        getAriaValueText={valueLabelFormat}
+        valueLabelFormat={valueLabelFormat}
+        onChange={handleChange}
+        aria-labelledby="non-linear-slider"
+      />
+      <div id='referenciasFechas'>
+        <div>
+          <h6 id='fechaInicio'>
+            {date2MonthYear(globalDates.min)}
+          </h6>
         </div>
-    </div>)
+        <div>  </div>
+        <div>
+          <h6 id='fechaCierre'>
+            {date2MonthYear(globalDates.max)}
+
+          </h6>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 MonthsSlider.propTypes = {
-    className: PropTypes.string,
-    monthRange: PropTypes.arrayOf(PropTypes.number).isRequired,
-    setMonthRange: PropTypes.func.isRequired,
-    totalMonths: PropTypes.number.isRequired,
-    startDateLabel: PropTypes.string.isRequired,
-    endDateLabel: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  globalDates: PropTypes.objectOf(PropTypes.instanceOf(Date)).isRequired,
+  setDates: PropTypes.func.isRequired,
 }
 
 MonthsSlider.defaultProps = {
-    className: "",
+  className: "",
 }

--- a/src/components/MonthsSlider.jsx
+++ b/src/components/MonthsSlider.jsx
@@ -12,7 +12,7 @@ const monthsDiff = (b, a) => {
 }
 
 export default function MonthsSlider({className, globalDates, setDates}) {
-  const months = useMemo(monthsDiff(globalDates.min, globalDates.max), [globalDates])
+  const months = useMemo(() => monthsDiff(globalDates.min, globalDates.max), [globalDates])
   const [monthRange, setMonthRange] = useState([0, months]);
 
   const valueLabelFormat = useCallback((value) => {

--- a/src/components/MonthsSlider.jsx
+++ b/src/components/MonthsSlider.jsx
@@ -4,7 +4,7 @@ import { Slider } from "@mui/material";
 
 import "./MonthsSlider.css";
 
-const date2MonthYear = d => `${d.getMonth()}/${d.getFullYear()}`
+const date2MonthYear = d => `${d.getMonth() + 1}/${d.getFullYear()}`
 const monthsDiff = (b, a) => {
   const yearsDiff = a.getFullYear() - b.getFullYear();
   const monthDiff = a.getMonth() - b.getMonth();


### PR DESCRIPTION
we change the MonthsSlider API to take only globalDates and setDates as props, the slider handles all it's date->int conversion and it doesn't spill out anymore.

this allows to reorganize App.jsx quite a bit leaving almost no date manipulation in that file, and greatly simplifying it's state management.

WARNING: we now use slider-container as it's name intends: to contain the slider plus the side button. that said this commit introduces a style change as now slider is grown by it's side button.

TODO: i'd love to get slider ticks.